### PR TITLE
Removed unused Libraries and Code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,16 +41,8 @@ wixProductUpgradeId := "4552fb0e-e257-4dbd-9ecb-dba9dbacf424"
 
 scalastyleConfig := baseDirectory.value / "project" / "scalastyle_config.xml"
 
-val http4sVersion = "0.21.0-M6"
-
 // Only necessary for SNAPSHOT releases
 resolvers += Resolver.sonatypeRepo("snapshots")
-
-libraryDependencies ++= Seq(
-  "org.http4s" %% "http4s-dsl" % http4sVersion,
-  "org.http4s" %% "http4s-blaze-client" % http4sVersion,
-  "org.http4s" %% "http4s-circe" % http4sVersion
-)
 
 libraryDependencies += "com.github.scopt" %% "scopt" % "3.7.1"
 libraryDependencies += "io.spray" %% "spray-json" % "1.3.5"

--- a/src/main/scala/de/upb/cs/swt/delphi/cli/DelphiCLI.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/cli/DelphiCLI.scala
@@ -29,16 +29,6 @@ object DelphiCLI {
 
   def main(args: Array[String]): Unit = {
 
-    def getEnvOrElse(envVar: String, defaultPath: String) = sys.env.getOrElse(envVar, defaultPath)
-
-    val javaLibPath = getEnvOrElse("JAVA_LIB_PATH", "/usr/lib/jvm/default-java/lib/")
-
-    val trustStorePath = getEnvOrElse("JAVA_TRUSTSTORE", "/usr/lib/jvm/default-java/lib/security/cacerts")
-
-    // This only is allowed to be set for GraalVM compiles...
-    //System.setProperty("java.library.path", javaLibPath)
-    //System.setProperty("javax.net.ssl.trustStore", trustStorePath)
-
     cliParser.parse(args, Config()) match {
       case Some(c) =>
 


### PR DESCRIPTION
**Reason for this PR**
In #27 some HTTP libraries have been introduced to the project's build definition in an effort to move away from Akka HTTP. Three ```http4s``` libraries are still part of the file but unused. Also there is dangeling code from previous work on supporting GraalVM native image releases, which is also unused (see discussion below #27).

**Changes in this PR**
* Removed build references to ```http4s-dsl```, ```http4s-blaze-client``` and ```http4s-circe```
* Removed unused code that was reading environment variables in an effort to support GraalVM native image releases